### PR TITLE
Rake task should not exit if successful

### DIFF
--- a/lib/fpm/rake_task.rb
+++ b/lib/fpm/rake_task.rb
@@ -54,6 +54,6 @@ class FPM::RakeTask < Rake::TaskLib
 
     args.flatten!.compact!
 
-    exit(FPM::Command.new("fpm").run(args) || 0)
+    abort 'FPM failed!' unless FPM::Command.new("fpm").run(args) == 0
   end
 end


### PR DESCRIPTION
Exiting after fpm success means that further rake tasks fail to execute,
and Rake simply exits. Instead, only abort if the fpm exits non-zero